### PR TITLE
update dill requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 2e096dd618a84d15aa369a9cf6695815e5539f853dc8fa4f4b9153b11b1d0b32
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,10 +21,10 @@ requirements:
     - pip
     - python
     - setuptools
-    - dill >=0.2.5
+    - dill >=0.3.5.1
   run:
     - python
-    - dill >=0.2.5
+    - dill >=0.3.5.1
 
 test:
   imports:


### PR DESCRIPTION
The upstream requirement on dill seems to get bumped continually, but this feedstock hasn't really represented that.

Bump to the newest lower bound, see [this](https://github.com/uqfoundation/multiprocess/commit/bce8cf7663ae14b6631f965705d6bc2f9e7dcee5) commit.

(noticed by running into problems on another feedstock with `pip check`)